### PR TITLE
let's compile to java 11 since 13 is eol

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,6 +71,8 @@ application {
 apply(plugin = "maven-publish")
 
 java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
     withSourcesJar()
 }
 


### PR DESCRIPTION
Let's make this Java 11 compatible since using java 13 requires an entire upgrade to our jvm based docker images and re marshall after some consult:
> jvm 13 is already EOL'd btw, so it's not a version we'd want to migrate tto...the next long term support version, 17, is the next release (several months away) so if we wanted to get ready for that we'd move to 16