### PR TITLE
Add idempotency

### DIFF
--- a/src/main/kotlin/com/classpass/moderntreasury/model/CreateLedgerAccountRequest.kt
+++ b/src/main/kotlin/com/classpass/moderntreasury/model/CreateLedgerAccountRequest.kt
@@ -1,9 +1,0 @@
-package com.classpass.moderntreasury.model
-
-data class CreateLedgerAccountRequest(
-    val name: String,
-    val description: String?,
-    val normalBalance: NormalBalanceType,
-    val ledgerId: String,
-    val metadata: Map<String, String> = emptyMap()
-)

--- a/src/main/kotlin/com/classpass/moderntreasury/model/LedgerEntry.kt
+++ b/src/main/kotlin/com/classpass/moderntreasury/model/LedgerEntry.kt
@@ -1,5 +1,7 @@
 package com.classpass.moderntreasury.model
 
+import com.fasterxml.jackson.annotation.JsonProperty
+
 /**
  * A LedgerEntry represents an accounting entry within a parent LedgerTransaction. Its amount is denominated in the
  * currency of the ledger it belongs to.
@@ -29,6 +31,8 @@ data class LedgerEntry(
 )
 
 enum class LedgerEntryDirection {
+    @JsonProperty("credit")
     CREDIT,
+    @JsonProperty("debit")
     DEBIT
 }

--- a/src/main/kotlin/com/classpass/moderntreasury/model/LedgerTransaction.kt
+++ b/src/main/kotlin/com/classpass/moderntreasury/model/LedgerTransaction.kt
@@ -1,5 +1,6 @@
 package com.classpass.moderntreasury.model
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.LocalDate
 import java.time.ZonedDateTime
 
@@ -61,14 +62,21 @@ data class LedgerTransaction(
 )
 
 enum class LedgerTransactionStatus {
+    @JsonProperty("pending")
     PENDING,
+    @JsonProperty("posted")
     POSTED,
+    @JsonProperty("archived")
     ARCHIVED
 }
 
 enum class LedgerableType {
+    @JsonProperty("payment_order")
     PAYMENT_ORDER,
+    @JsonProperty("expected_payment")
     EXPECTED_PAYMENT,
+    @JsonProperty("paper_item")
     PAPER_ITEM,
+    @JsonProperty("return")
     RETURN
 }

--- a/src/main/kotlin/com/classpass/moderntreasury/model/request/CreateLedgerAccountRequest.kt
+++ b/src/main/kotlin/com/classpass/moderntreasury/model/request/CreateLedgerAccountRequest.kt
@@ -1,0 +1,12 @@
+package com.classpass.moderntreasury.model.request
+
+import com.classpass.moderntreasury.model.NormalBalanceType
+
+data class CreateLedgerAccountRequest(
+    val name: String,
+    val description: String?,
+    val normalBalance: NormalBalanceType,
+    val ledgerId: String,
+    override val idempotencyKey: String,
+    val metadata: RequestMetadata = emptyMap()
+) : IdempotentRequest

--- a/src/main/kotlin/com/classpass/moderntreasury/model/request/IdempotentRequest.kt
+++ b/src/main/kotlin/com/classpass/moderntreasury/model/request/IdempotentRequest.kt
@@ -1,0 +1,31 @@
+package com.classpass.moderntreasury.model.request
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+
+/**
+ * The Modern Treasury API supports idempotent requests to help prevent you from accidentally issuing the same API call
+ * twice. This feature can be helpful if you are instructing us to move money, create an entity, or make changes to an
+ * existing resource. For example, if you are creating a Payment Order and the request fails due to a network issue, you
+ * can retry the request with the same idempotency key to guarantee the payment order was only created once.
+ *
+ * When a successful request is made with an idempotency key, ModernTreasury will save the result of that request for 24
+ * hours. If you issue a new request within 24 hours using the same credentials and idempotency key, ModernTreasury will
+ * echo the original response (status code and body) back to you.
+ *
+ * A few things to note:
+ * - Results are only saved if the request successfully executed.
+ * - If there was a connection interruption or another error that prevented us from completing the original request,
+ *   ModernTreasury will execute the following request and cache its results.
+ * - Idempotency keys are independent of the route. For example if you use a key to create a payment order and then use
+ *   the same key to create a counterparty within 24 hours, you will received the cached result of the first payment order request.
+ *
+ * MT Docs reference: https://docs.moderntreasury.com/reference#idempotent-requests
+ */
+interface IdempotentRequest {
+    /**
+     * Unique idempotency key for this request. Requests with the same idempotency key can be retried without fear of
+     * issuing the same API call multiple times.
+     */
+    @get:JsonIgnore
+    val idempotencyKey: String
+}

--- a/src/main/kotlin/com/classpass/moderntreasury/model/request/RequestMetadata.kt
+++ b/src/main/kotlin/com/classpass/moderntreasury/model/request/RequestMetadata.kt
@@ -1,0 +1,7 @@
+package com.classpass.moderntreasury.model.request
+
+/**
+ * In requests to ModernTreasury, metadata can be included as a map of strings. If you would like to remove metadata
+ * that is already set, you can unset it by passing in the key-value pair with an empty string or null as the value.
+ */
+typealias RequestMetadata = Map<String, String?>

--- a/src/test/kotlin/com/classpass/moderntreasury/client/LedgerAccountTests.kt
+++ b/src/test/kotlin/com/classpass/moderntreasury/client/LedgerAccountTests.kt
@@ -2,14 +2,13 @@ package com.classpass.moderntreasury.client
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import com.classpass.moderntreasury.model.CreateLedgerAccountRequest
 import com.classpass.moderntreasury.model.LedgerAccount
 import com.classpass.moderntreasury.model.LedgerAccountBalance
 import com.classpass.moderntreasury.model.LedgerAccountBalanceItem
 import com.classpass.moderntreasury.model.NormalBalanceType
+import com.classpass.moderntreasury.model.request.CreateLedgerAccountRequest
 import com.github.tomakehurst.wiremock.client.WireMock.equalToJson
 import com.github.tomakehurst.wiremock.client.WireMock.get
-import com.github.tomakehurst.wiremock.client.WireMock.ok
 import com.github.tomakehurst.wiremock.client.WireMock.post
 import com.github.tomakehurst.wiremock.client.WireMock.stubFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlMatching
@@ -19,28 +18,7 @@ class LedgerAccountTests : WireMockClientTest() {
 
     @Test
     fun testGetBalance() {
-        val response = """
-        {
-          "pending": [
-            {
-              "credits": 6,
-              "debits": 23,
-              "amount": -17,
-              "currency": "USD"
-            }
-          ],
-          "posted": [
-            {
-              "credits": 0,
-              "debits": 11,
-              "amount": -11,
-              "currency": "USD"
-            }
-          ]
-        }    
-        """.trimIndent()
-
-        stubFor(get(urlMatching("/ledger_accounts/.+/balance")).willReturn(ok(response)))
+        stubFor(get(urlMatching("/ledger_accounts/.+/balance")).willReturn(ledgerAccountBalanceResponse))
         val expectedDeserialized = LedgerAccountBalance(
             pending = listOf(LedgerAccountBalanceItem(6, 23, -17, "USD")),
             posted = listOf(LedgerAccountBalanceItem(0, 11, -11, "USD"))
@@ -51,22 +29,13 @@ class LedgerAccountTests : WireMockClientTest() {
 
     @Test
     fun `createLedgerAccount makes a well-formatted request body and deserializes responses properly`() {
-        val response = """
-            {
-                "id": "f1c7e474-e6d5-4741-9f76-04510c8b6d7a",
-                "object": "ledger_account",
-                "name": "Operating Bank Account",
-                "ledger_id": "89c8bd30-e06a-4a79-b396-e6c7e13e7a12",
-                "description": null,
-                "normal_balance": "debit",
-                "metadata": {},
-                "live_mode": true,
-                "created_at": "2020-08-04T16:54:32Z",
-                "updated_at": "2020-08-04T16:54:32Z"
-            }
-        """
-
-        val request = CreateLedgerAccountRequest("the_name", "the_description", NormalBalanceType.CREDIT, "1234")
+        val request = CreateLedgerAccountRequest(
+            "the_name",
+            "the_description",
+            NormalBalanceType.CREDIT,
+            "1234",
+            "idempotencykey"
+        )
         val expectedRequestJson = """
             {
                 "name": "the_name",
@@ -79,14 +48,14 @@ class LedgerAccountTests : WireMockClientTest() {
         stubFor(
             post(urlMatching("/ledger_accounts"))
                 .withRequestBody(equalToJson(expectedRequestJson))
-                .willReturn(ok(response))
+                .willReturn(ledgerAccountResponse)
         )
 
         val actualResponse = client.createLedgerAccount(request).get()
         val expectedDeserialized = LedgerAccount(
-            id = "f1c7e474-e6d5-4741-9f76-04510c8b6d7a",
+            id = "f1c7-xxxxx",
             name = "Operating Bank Account",
-            ledgerId = "89c8bd30-e06a-4a79-b396-e6c7e13e7a12",
+            ledgerId = "89c8-xxxxx",
             description = null,
             normalBalance = NormalBalanceType.DEBIT,
             metadata = emptyMap(),

--- a/src/test/kotlin/com/classpass/moderntreasury/client/WireMockClientTest.kt
+++ b/src/test/kotlin/com/classpass/moderntreasury/client/WireMockClientTest.kt
@@ -2,7 +2,9 @@ package com.classpass.moderntreasury.client
 
 import com.classpass.moderntreasury.config.ModernTreasuryConfig
 import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder
 import com.github.tomakehurst.wiremock.client.WireMock.configureFor
+import com.github.tomakehurst.wiremock.client.WireMock.ok
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
@@ -16,7 +18,7 @@ open class WireMockClientTest {
     internal val API_KEY = "api_key"
 
     private val wireMockServer = WireMockServer(WireMockConfiguration.options().dynamicPort())
-    lateinit var client: ModernTreasuryClient
+    internal lateinit var client: AsyncModernTreasuryClient
 
     @BeforeAll
     fun beforeAll() {
@@ -40,4 +42,79 @@ open class WireMockClientTest {
     fun afterAll() {
         wireMockServer.stop()
     }
+
+    protected val ledgerAccountResponse: ResponseDefinitionBuilder = ok(
+        """
+            {
+                "id": "f1c7-xxxxx",
+                "object": "ledger_account",
+                "name": "Operating Bank Account",
+                "ledger_id": "89c8-xxxxx",
+                "description": null,
+                "normal_balance": "debit",
+                "metadata": {},
+                "live_mode": true,
+                "created_at": "2020-08-04T16:54:32Z",
+                "updated_at": "2020-08-04T16:54:32Z"
+            }
+        """
+    )
+
+    protected val ledgerAccountBalanceResponse = ok(
+        """
+        {
+          "pending": [
+            {
+              "credits": 6,
+              "debits": 23,
+              "amount": -17,
+              "currency": "USD"
+            }
+          ],
+          "posted": [
+            {
+              "credits": 0,
+              "debits": 11,
+              "amount": -11,
+              "currency": "USD"
+            }
+          ]
+        }    
+        """
+    )
+
+    protected val ledgerTransactionResponse = ok(
+        """
+        {
+          "id": "4f5b1dd9-xxx123",
+          "object": "ledger_transaction",
+          "live_mode": false,
+          "external_id": "zwt3-xxx123",
+          "ledgerable_type": null,
+          "ledgerable_id": null,
+          "ledger_id": "0aa9c435-xxx123",
+          "description": "test 3 pending",
+          "status": "pending",
+          "ledger_entries": [
+            {
+              "id": "4492f794-xxx123",
+              "object": "ledger_entry",
+              "live_mode": false,
+              "amount": 6,
+              "direction": "credit",
+              "ledger_account_id": "f3e54ff6-xxx123",
+              "ledger_transaction_id": "4f5b1dd9-xxx123",
+              "discarded_at": null,
+              "created_at": "2021-05-04T21:44:08Z",
+              "updated_at": "2021-05-04T21:44:08Z"
+            }
+          ],
+          "posted_at": "2020-10-20T19:11:07Z",
+          "effective_date": "2021-05-04",
+          "metadata": {},
+          "created_at": "2021-05-04T21:44:08Z",
+          "updated_at": "2021-05-04T21:44:08Z"
+        }
+        """
+    )
 }


### PR DESCRIPTION
This PR adds idempotency to all POST requests from the ModernTreasuryClient. A required `idempotencyKey` must now be included in POST requests

- This restriction does not apply to PATCH requests. I've confirmed with MT that their PATCH requests are idempotent already and don't need idempotency keys (https://classpass.slack.com/archives/C01RP0MSV36/p1620682383037500)