### PR TITLE
Rename ModernTreasuryFake

### DIFF
--- a/client/src/main/kotlin/com/classpass/moderntreasury/fake/ModernTreasuryFake.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/fake/ModernTreasuryFake.kt
@@ -31,7 +31,7 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletableFuture.completedFuture
 import java.util.concurrent.CompletableFuture.supplyAsync
 
-class FakeModernTreasuryClient
+class ModernTreasuryFake
 constructor(val clock: Clock) :
     ModernTreasuryClient {
     private val accounts: MutableMap<LedgerAccountId, LedgerAccount> = mutableMapOf()

--- a/client/src/test/kotlin/com/classpass/moderntreasury/fake/ModernTreasuryFakeTest.kt
+++ b/client/src/test/kotlin/com/classpass/moderntreasury/fake/ModernTreasuryFakeTest.kt
@@ -20,9 +20,9 @@ val NIK = "" // No idempotency key.
 val TODAY = LocalDate.now(CLOCK)
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class FakeModernTreasuryClientTest {
+class ModernTreasuryFakeTest {
 
-    val client = FakeModernTreasuryClient(CLOCK)
+    val client = ModernTreasuryFake(CLOCK)
 
     val usd = client.createLedger("USD", "", "USD", NIK).get()
     val can = client.createLedger("CAN", "", "CAN", NIK).get()


### PR DESCRIPTION
In testing nomenclature, fake is a noun, not an adjective.