### PR TITLE
FIN-2466 getLedgerAccounts function

### DIFF
--- a/client/src/main/kotlin/com/classpass/moderntreasury/client/AsyncModernTreasuryClient.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/client/AsyncModernTreasuryClient.kt
@@ -85,6 +85,21 @@ internal class AsyncModernTreasuryClient(
         return get("/ledger_accounts/$ledgerAccountId", queryParams)
     }
 
+    override fun getLedgerAccounts(
+        ledgerAccountIds: List<LedgerAccountId>,
+        balancesAsOfDate: LocalDate?,
+        page: Int,
+        perPage: Int
+    ): CompletableFuture<ModernTreasuryPage<LedgerAccount>> {
+        val queryParams = mapOf(
+            "balances[as_of_date]" to listOfNotNull(balancesAsOfDate?.toString()),
+            "id[]" to ledgerAccountIds.map { it.toString() },
+            "page" to listOf(page.toString()),
+            "per_page" to listOf(perPage.toString())
+        )
+        return getPaginated("/ledger_accounts", queryParams)
+    }
+
     override fun getLedgerTransaction(id: LedgerTransactionId): CompletableFuture<LedgerTransaction> =
         get("/ledger_transactions/$id")
 

--- a/client/src/main/kotlin/com/classpass/moderntreasury/client/ModernTreasuryClient.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/client/ModernTreasuryClient.kt
@@ -49,6 +49,16 @@ interface ModernTreasuryClient : Closeable {
         balancesAsOfDate: LocalDate? = null
     ): CompletableFuture<LedgerAccount>
 
+    fun getLedgerAccounts(
+        ledgerAccountIds: List<LedgerAccountId>,
+        /**
+         * The date of the balance in local time. Defaults to today's date.
+         */
+        balancesAsOfDate: LocalDate? = null,
+        page: Int = 1,
+        perPage: Int = 25
+    ): CompletableFuture<ModernTreasuryPage<LedgerAccount>>
+
     fun getLedgerTransaction(
         /**
          * The ID of the ledger transaction

--- a/client/src/main/kotlin/com/classpass/moderntreasury/fake/ModernTreasuryFake.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/fake/ModernTreasuryFake.kt
@@ -77,6 +77,24 @@ open class ModernTreasuryFake :
         accounts[ledgerAccountId]!!
     }
 
+    override fun getLedgerAccounts(
+        ledgerAccountIds: List<LedgerAccountId>,
+        balancesAsOfDate: LocalDate?,
+        page: Int,
+        perPage: Int
+    ): CompletableFuture<ModernTreasuryPage<LedgerAccount>> = supplyAsync {
+        val accounts = ledgerAccountIds.mapNotNull {
+            accounts[it]?.copy(balances = getBalances(it, asOfDate = balancesAsOfDate))
+        }
+        val modernTreasuryPageInfo = object : ModernTreasuryPageInfo {
+            override val page = page
+            override val perPage = perPage
+            override val totalCount = accounts.size
+        }
+        val content = accounts.drop(page * perPage).take(perPage)
+        ModernTreasuryPage(modernTreasuryPageInfo, content)
+    }
+
     override fun createLedgerAccount(request: CreateLedgerAccountRequest): CompletableFuture<LedgerAccount> = supplyAsync {
         val ledger = ledgers[request.ledgerId]
             ?: throwApiException("Ledger Not Found")


### PR DESCRIPTION
This PR adds a function to the client for getting a list of ledger accounts.  The corresponding MT api endpoint is https://docs.moderntreasury.com/reference#list-ledger-accounts