### PR TITLE
Make unordered entries set have appropriate type

### DIFF
--- a/client/src/main/kotlin/com/classpass/moderntreasury/fake/ModernTreasuryFake.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/fake/ModernTreasuryFake.kt
@@ -215,7 +215,7 @@ open class ModernTreasuryFake :
                 description = request.description,
                 status = status,
                 metadata = metadata,
-                ledgerEntries = ledgerEntries,
+                ledgerEntries = ledgerEntries.toSet(),
                 postedAt = postedAt,
                 effectiveDate = request.effectiveDate,
                 ledgerId = ledgerAccount1.ledgerId,
@@ -291,7 +291,7 @@ open class ModernTreasuryFake :
         val updated = transaction.copy(
             description = request.description ?: transaction.description,
             status = request.status ?: transaction.status,
-            ledgerEntries = ledgerEntries ?: transaction.ledgerEntries,
+            ledgerEntries = ledgerEntries?.toSet() ?: transaction.ledgerEntries,
             metadata = metadata
         )
 

--- a/client/src/main/kotlin/com/classpass/moderntreasury/model/LedgerTransaction.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/model/LedgerTransaction.kt
@@ -30,7 +30,7 @@ data class LedgerTransaction(
      * https://docs.moderntreasury.com/reference#metadata.
      */
     val metadata: Map<String, String>,
-    val ledgerEntries: List<LedgerEntry>,
+    val ledgerEntries: Set<LedgerEntry>,
     /**
      * The time on which the ledger transaction posted. This is null if the ledger transaction is pending.
      */

--- a/client/src/test/kotlin/com/classpass/moderntreasury/client/LedgerTransactionTests.kt
+++ b/client/src/test/kotlin/com/classpass/moderntreasury/client/LedgerTransactionTests.kt
@@ -43,7 +43,7 @@ class LedgerTransactionTests : WireMockClientTest() {
             description = "test 3 pending",
             status = LedgerTransactionStatus.PENDING,
             metadata = emptyMap(),
-            ledgerEntries = listOf(
+            ledgerEntries = setOf(
                 LedgerEntry(
                     id = ledgerEntryId,
                     liveMode = false,


### PR DESCRIPTION
One of the live tests fails in https://github.com/classpass/moderntreasury-client/pull/55. It fails because some ledger transaction entries come back in a different order, so two same transactions aren't equals. [MT support say entries are unordered](https://classpass.slack.com/archives/C01RP0MSV36/p1633470672064900). The [MT api docs](https://docs.moderntreasury.com/reference#ledger-transaction-object) call `ledger_entries` an "array". Changing entries to a `Set` from a `List` seems like the most reasonable thing to do here.