### PR TITLE
Avoid jar artifact name conflict

### DIFF
--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -24,7 +24,7 @@ configure<PublishingExtension> {
         publications {
             create<MavenPublication>("mavenJava") {
                 // Give the resulting artifact a name that won't conflict with other projects
-                artifactId = "${project.group.toString().split(".").last()}-${project.name}"
+                artifactId = "modern-treasury-client"
 
                 from(components["java"])
             }


### PR DESCRIPTION
We have projects with subprojects that use `${project.group.toString().split(".").last()}-${project.name}`. I wasn't exactly sure what the result of this was going to be and it didn't seem obviously better than just hardcoding.