### PR TITLE
Be able to create client with response header callback object

### DIFF
--- a/client/src/main/kotlin/com/classpass/moderntreasury/SandboxTest.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/SandboxTest.kt
@@ -3,6 +3,7 @@
 package com.classpass.moderntreasury
 
 import com.classpass.moderntreasury.client.AsyncModernTreasuryClient
+import com.classpass.moderntreasury.client.DO_NOTHING_RESPONSE_CALLBACK
 import com.classpass.moderntreasury.config.ModernTreasuryConfig
 
 /**
@@ -12,7 +13,7 @@ import com.classpass.moderntreasury.config.ModernTreasuryConfig
  */
 fun main(args: Array<String>) {
     val config = ModernTreasuryConfig(args[0], args[1], args[2])
-    AsyncModernTreasuryClient.create(config).use { client ->
+    AsyncModernTreasuryClient.create(config, DO_NOTHING_RESPONSE_CALLBACK).use { client ->
         client.ping().get()
     }
 }

--- a/client/src/main/kotlin/com/classpass/moderntreasury/client/ResponseCallback.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/client/ResponseCallback.kt
@@ -1,0 +1,12 @@
+package com.classpass.moderntreasury.client
+
+/**
+ * Called my the ModernTreasuryClient with response header information resulting from each request the client executes.
+ */
+fun interface ResponseCallback {
+    fun rateLimitRemaining(rateLimitRemaining: Int)
+}
+
+val DO_NOTHING_RESPONSE_CALLBACK = ResponseCallback {
+    // don't do anything
+}

--- a/client/src/test/kotlin/com/classpass/moderntreasury/client/RateLimitingTest.kt
+++ b/client/src/test/kotlin/com/classpass/moderntreasury/client/RateLimitingTest.kt
@@ -37,7 +37,13 @@ class RateLimitingTest {
         wireMockServer.start()
         baseUrl = "http://localhost:${wireMockServer.port()}"
         val asyncHttpClient = Dsl.asyncHttpClient()
-        client = AsyncModernTreasuryClient(asyncHttpClient, baseUrl, rateLimiter, rateLimiterTimeoutMs)
+        client = AsyncModernTreasuryClient(
+            asyncHttpClient,
+            baseUrl,
+            rateLimiter,
+            rateLimiterTimeoutMs,
+            DO_NOTHING_RESPONSE_CALLBACK,
+        )
 
         configureFor("localhost", wireMockServer.port())
     }

--- a/client/src/test/kotlin/com/classpass/moderntreasury/client/WireMockClientTest.kt
+++ b/client/src/test/kotlin/com/classpass/moderntreasury/client/WireMockClientTest.kt
@@ -30,7 +30,7 @@ open class WireMockClientTest {
     internal open fun buildClient(): AsyncModernTreasuryClient {
         val baseUrl = "http://localhost:${wireMockServer.port()}"
         val config = ModernTreasuryConfig(ORG_ID, API_KEY, baseUrl)
-        return AsyncModernTreasuryClient.create(config)
+        return AsyncModernTreasuryClient.create(config, DO_NOTHING_RESPONSE_CALLBACK)
     }
 
     @BeforeEach

--- a/live-test/src/test/kotlin/com/classpass/moderntreasury/ModernTreasuryLiveTest.kt
+++ b/live-test/src/test/kotlin/com/classpass/moderntreasury/ModernTreasuryLiveTest.kt
@@ -24,7 +24,11 @@ open class ModernTreasuryLiveTest {
                 throw IllegalArgumentException("Live tests must use the test API Key!")
             }
             client =
-                asyncModernTreasuryClient(ModernTreasuryConfig(props.getProperty("orgId"), props.getProperty("apiKey")))
+                asyncModernTreasuryClient(
+                    ModernTreasuryConfig(props.getProperty("orgId"), props.getProperty("apiKey"))
+                ) {
+                    println("In ModernTreasuryLiveTest, rate limit remaining was $it")
+                }
         } catch (e: IOException) {
             throw Exception("Unable to load live-tests.properties", e)
         }


### PR DESCRIPTION
The aim here is for a service using the MT client to be able to register a callback object, that gets told the value of the `X-Rate-Limit-Remaining` header every time a response comes back.

(Yes, I remembered to run the live tests for this PR!)