### PR TITLE
Publish to maven central

### DIFF
--- a/live-test/build.gradle.kts
+++ b/live-test/build.gradle.kts
@@ -1,4 +1,4 @@
-group = "com.classpass.moderntreasury"
+group = "com.classpass.oss.moderntreasury"
 
 tasks.withType<Test> {
     onlyIf {


### PR DESCRIPTION
So this project can be published to its Sonatype repo. Copied from https://github.com/classpass/flink-kotlin/pull/2

Of note:
* Adds creation of a javadoc using dokka, because Sonatype validation requires a javadoc jar
* Updates group ids to include `oss`, so they start `com.classpass.oss` (another Sonatype validation requirement)