### PR TITLE
Update test to reflect MT api change to 200

### DIFF
--- a/live-test/src/test/kotlin/com/classpass/moderntreasury/client/LedgerAccountLiveTest.kt
+++ b/live-test/src/test/kotlin/com/classpass/moderntreasury/client/LedgerAccountLiveTest.kt
@@ -100,7 +100,7 @@ class LedgerAccountLiveTest : ModernTreasuryLiveTest() {
     }
 
     @Test
-    fun `When posting already-posted transaction then throws TransactionAlreadyPostedException`() {
+    fun `When posting already-posted transaction then patch has no effect`() {
         val transactionRequest = CreateLedgerTransactionRequest(
             LocalDate.now(),
             listOf(
@@ -114,9 +114,8 @@ class LedgerAccountLiveTest : ModernTreasuryLiveTest() {
         )
 
         val txn = client.createLedgerTransaction(transactionRequest).get()
-        val thrown =
-            assertFails { client.updateLedgerTransaction(id = txn.id, status = LedgerTransactionStatus.POSTED).get() }
-        assertThat(thrown.cause).isNotNull().isInstanceOf(TransactionAlreadyPostedException::class)
+        val updatedTxn = client.updateLedgerTransaction(id = txn.id, status = LedgerTransactionStatus.POSTED).get()
+        assertEquals(txn, updatedTxn)
     }
 
     @Test


### PR DESCRIPTION
Confirmed with MT support -
The MT API used to return an HTTP 422 if you try to patch a transaction to posted when it is already in a posted state. MT have changed this behavior to return an HTTP 200 in this case, since "we indicate in our docs that our PATCH endpoints are idempotent by design. So if you post an already posted transaction, it will return the same result as if you posted a pending transaction."