### PR TITLE
Allow main not master

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -166,3 +166,10 @@ nexusPublishing {
 application {
     mainClass.set("MainKt")
 }
+
+release {
+    // work around lack of proper kotlin DSL support
+    (getProperty("git") as net.researchgate.release.GitAdapter.GitConfig).apply {
+        requireBranch = "main"
+    }
+}


### PR DESCRIPTION
To fix:
```
* What went wrong:
Execution failed for task ':moderntreasury-client:initScmAdapter'.
> Current Git branch is "main" and not "master".
```

Working around [this issue](https://github.com/researchgate/gradle-release/issues/340).