### PR TITLE
Add version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 kotlin.code.style=official
+version = 4.0.4-SNAPSHOT


### PR DESCRIPTION
Because otherwise the result of `./gradlew release` is:
```
* What went wrong:
Execution failed for task ':moderntreasury-client:unSnapshotVersion'.
> [/Users/jstafford/proj/moderntreasury-client/gradle.properties] contains no 'version' property. Expression: properties.version
```