### PR TITLE
Js/relpub

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -172,6 +172,6 @@ application {
 release {
     // work around lack of proper kotlin DSL support
     (getProperty("git") as net.researchgate.release.GitAdapter.GitConfig).apply {
-        requireBranch = "js/relpub"
+        requireBranch = "main"
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -142,12 +142,12 @@ subprojects {
         }
     }
 
+    // releasing should publish
+    rootProject.tasks.afterReleaseBuild {
+        dependsOn(provider { project.tasks.named("publishToSonatype") })
+    }
 }
 
-// releasing should publish
-rootProject.tasks.afterReleaseBuild {
-    dependsOn(provider { project.tasks.named("publishToSonatype") })
-}
 
 nexusPublishing {
     repositories {
@@ -171,6 +171,6 @@ application {
 release {
     // work around lack of proper kotlin DSL support
     (getProperty("git") as net.researchgate.release.GitAdapter.GitConfig).apply {
-        requireBranch = "main"
+        requireBranch = "js/relpub"
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -143,8 +143,9 @@ subprojects {
     }
 
     // releasing should publish
+    val provider = provider { project.tasks.named("publishToSonatype") }
     rootProject.tasks.afterReleaseBuild {
-        dependsOn(provider { project.tasks.named("publishToSonatype") })
+        dependsOn(provider)
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 kotlin.code.style=official
-version = 4.0.4-SNAPSHOT
+version = 4.0.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 kotlin.code.style=official
-version = 4.0.4
+version = 4.0.5-SNAPSHOT


### PR DESCRIPTION
The error message was:
```
Could not determine the dependencies of task ':moderntreasury-client:moderntreasury-client:afterReleaseBuild'.
> Task with name 'publishToSonatype' not found in project ':moderntreasury-client:moderntreasury-client'.
```

For some reason, pulling out the `provider` declaration fixes this. Presumably `project` ends up referring to a different project?!