### PR TITLE
Use cursor pagination

### DIFF
--- a/client/src/main/kotlin/com/classpass/moderntreasury/client/AsyncModernTreasuryClient.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/client/AsyncModernTreasuryClient.kt
@@ -117,14 +117,14 @@ internal class AsyncModernTreasuryClient(
     override fun getLedgerAccounts(
         ledgerAccountIds: List<LedgerAccountId>,
         balancesAsOfDate: LocalDate?,
-        afterCursor: LedgerAccountId?,
+        afterCursor: String?,
         perPage: Int
     ): CompletableFuture<ModernTreasuryPage<LedgerAccount>> {
         val queryParams = mapOf(
             "balances[as_of_date]" to listOfNotNull(balancesAsOfDate?.toString()),
             "id[]" to ledgerAccountIds.map { it.toString() },
             "per_page" to listOf(perPage.toString())
-        ).plus(afterCursor?.let { mapOf("after_cursor" to listOf(afterCursor.toString())) } ?: emptyMap())
+        ).plus(afterCursor?.let { mapOf("after_cursor" to listOf(afterCursor)) } ?: emptyMap())
         return getPaginated("/ledger_accounts", queryParams)
     }
 
@@ -138,14 +138,14 @@ internal class AsyncModernTreasuryClient(
         effectiveDate: DateQuery?,
         postedAt: InstantQuery?,
         updatedAt: InstantQuery?,
-        afterCursor: LedgerTransactionId?,
+        afterCursor: String?,
         perPage: Int
     ): CompletableFuture<ModernTreasuryPage<LedgerTransaction>> {
         val queryParams = mapOf(
             "ledger_id" to listOfNotNull(ledgerId?.toString()),
             "ledger_account_id" to listOfNotNull(ledgerAccountId?.toString()),
             "per_page" to listOf(perPage.toString())
-        ).plus(afterCursor?.let { mapOf("after_cursor" to listOf(afterCursor.toString())) } ?: emptyMap())
+        ).plus(afterCursor?.let { mapOf("after_cursor" to listOf(afterCursor)) } ?: emptyMap())
             .plus(effectiveDate?.toQueryParams("effective_date") ?: emptyMap())
             .plus(postedAt?.toQueryParams("posted_at") ?: emptyMap())
             .plus(updatedAt?.toQueryParams("updated_at") ?: emptyMap())

--- a/client/src/main/kotlin/com/classpass/moderntreasury/client/AsyncModernTreasuryClient.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/client/AsyncModernTreasuryClient.kt
@@ -117,15 +117,14 @@ internal class AsyncModernTreasuryClient(
     override fun getLedgerAccounts(
         ledgerAccountIds: List<LedgerAccountId>,
         balancesAsOfDate: LocalDate?,
-        page: Int,
+        afterCursor: LedgerAccountId?,
         perPage: Int
     ): CompletableFuture<ModernTreasuryPage<LedgerAccount>> {
         val queryParams = mapOf(
             "balances[as_of_date]" to listOfNotNull(balancesAsOfDate?.toString()),
             "id[]" to ledgerAccountIds.map { it.toString() },
-            "page" to listOf(page.toString()),
             "per_page" to listOf(perPage.toString())
-        )
+        ).plus(afterCursor?.let { mapOf("after_cursor" to listOf(afterCursor.toString())) } ?: emptyMap())
         return getPaginated("/ledger_accounts", queryParams)
     }
 
@@ -139,15 +138,15 @@ internal class AsyncModernTreasuryClient(
         effectiveDate: DateQuery?,
         postedAt: InstantQuery?,
         updatedAt: InstantQuery?,
-        page: Int,
+        afterCursor: LedgerTransactionId?,
         perPage: Int
     ): CompletableFuture<ModernTreasuryPage<LedgerTransaction>> {
         val queryParams = mapOf(
             "ledger_id" to listOfNotNull(ledgerId?.toString()),
             "ledger_account_id" to listOfNotNull(ledgerAccountId?.toString()),
-            "page" to listOf(page.toString()),
             "per_page" to listOf(perPage.toString())
-        ).plus(effectiveDate?.toQueryParams("effective_date") ?: emptyMap())
+        ).plus(afterCursor?.let { mapOf("after_cursor" to listOf(afterCursor.toString())) } ?: emptyMap())
+            .plus(effectiveDate?.toQueryParams("effective_date") ?: emptyMap())
             .plus(postedAt?.toQueryParams("posted_at") ?: emptyMap())
             .plus(updatedAt?.toQueryParams("updated_at") ?: emptyMap())
             .plus(metadata.toQueryParams())

--- a/client/src/main/kotlin/com/classpass/moderntreasury/client/FetchAllPages.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/client/FetchAllPages.kt
@@ -28,7 +28,7 @@ private const val PER_PAGE_MAX = 100
  * comprising the content of all the pages concatenated
  *
  * Example usage:
- * mtClient.fetchAllPages { afterCursor, perPage -> getLedgerTransactions(ledgerId, null, afterCursor = afterCursor?.let { LedgerTransactionId(it) }, perPage = perPage) }
+ * mtClient.fetchAllPages { afterCursor, perPage -> getLedgerTransactions(ledgerId, null, afterCursor = afterCursor, perPage = perPage) }
  */
 fun <T> ModernTreasuryClient.fetchAllPages(
     fetchPage: ModernTreasuryClient.(paginatedFnAfterCursor: String?, paginatedFnPerPage: Int) -> CompletableFuture<ModernTreasuryPage<T>>,

--- a/client/src/main/kotlin/com/classpass/moderntreasury/client/ModernTreasuryClient.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/client/ModernTreasuryClient.kt
@@ -72,7 +72,7 @@ interface ModernTreasuryClient : Closeable {
          * The date of the balance in local time. Defaults to today's date.
          */
         balancesAsOfDate: LocalDate? = null,
-        afterCursor: LedgerAccountId? = null,
+        afterCursor: String? = null,
         perPage: Int = 25
     ): CompletableFuture<ModernTreasuryPage<LedgerAccount>>
 
@@ -96,7 +96,7 @@ interface ModernTreasuryClient : Closeable {
         effectiveDate: DateQuery? = null,
         postedAt: InstantQuery? = null,
         updatedAt: InstantQuery? = null,
-        afterCursor: LedgerTransactionId? = null,
+        afterCursor: String? = null,
         perPage: Int = 25
     ): CompletableFuture<ModernTreasuryPage<LedgerTransaction>>
 

--- a/client/src/main/kotlin/com/classpass/moderntreasury/client/ModernTreasuryClient.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/client/ModernTreasuryClient.kt
@@ -72,7 +72,7 @@ interface ModernTreasuryClient : Closeable {
          * The date of the balance in local time. Defaults to today's date.
          */
         balancesAsOfDate: LocalDate? = null,
-        page: Int = 1,
+        afterCursor: LedgerAccountId? = null,
         perPage: Int = 25
     ): CompletableFuture<ModernTreasuryPage<LedgerAccount>>
 
@@ -96,7 +96,7 @@ interface ModernTreasuryClient : Closeable {
         effectiveDate: DateQuery? = null,
         postedAt: InstantQuery? = null,
         updatedAt: InstantQuery? = null,
-        page: Int = 1,
+        afterCursor: LedgerTransactionId? = null,
         perPage: Int = 25
     ): CompletableFuture<ModernTreasuryPage<LedgerTransaction>>
 

--- a/client/src/main/kotlin/com/classpass/moderntreasury/fake/ModernTreasuryFake.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/fake/ModernTreasuryFake.kt
@@ -97,7 +97,7 @@ open class ModernTreasuryFake :
     override fun getLedgerAccounts(
         ledgerAccountIds: List<LedgerAccountId>,
         balancesAsOfDate: LocalDate?,
-        afterCursor: LedgerAccountId?,
+        afterCursor: String?,
         perPage: Int
     ): CompletableFuture<ModernTreasuryPage<LedgerAccount>> = supplyAsync {
         // Create a local copy of ledger account info with computed balance. Does not mutate shared.
@@ -105,11 +105,11 @@ open class ModernTreasuryFake :
             accounts[it]?.copy(balances = getBalances(it, asOfDate = balancesAsOfDate))
         }
 
-        val accountsAfterCursor = accounts.takeLastWhile { afterCursor != it.id }
+        val accountsAfterCursor = accounts.takeLastWhile { afterCursor != it.id.toString() }
 
         val content = accountsAfterCursor.take(perPage)
         val nextAfterCursor =
-            if (accountsAfterCursor.size <= perPage) null else content.lastOrNull()?.id.toString()
+            if (accountsAfterCursor.isEmpty()) null else content.lastOrNull()?.id.toString()
 
         val modernTreasuryPageInfo = object : ModernTreasuryPageInfo {
             override val afterCursor: String? = nextAfterCursor
@@ -164,7 +164,7 @@ open class ModernTreasuryFake :
         effectiveDate: DateQuery?,
         postedAt: InstantQuery?,
         updatedAt: InstantQuery?,
-        afterCursor: LedgerTransactionId?,
+        afterCursor: String?,
         perPage: Int
     ): CompletableFuture<ModernTreasuryPage<LedgerTransaction>> {
         val filteredTransactions = transactions
@@ -180,11 +180,11 @@ open class ModernTreasuryFake :
             }
             .filter { ledgerAccountId == null || it.ledgerEntries.map { entry -> entry.ledgerAccountId }.contains(ledgerAccountId) }
 
-        val transactionsAfterCursor = filteredTransactions.takeLastWhile { afterCursor != it.id }
+        val transactionsAfterCursor = filteredTransactions.takeLastWhile { afterCursor != it.id.toString() }
 
         val pageContent = transactionsAfterCursor.take(perPage)
         val nextAfterCursor =
-            if (transactionsAfterCursor.size <= perPage) null else pageContent.lastOrNull()?.id.toString()
+            if (transactionsAfterCursor.isEmpty()) null else pageContent.lastOrNull()?.id.toString()
 
         val modernTreasuryPageInfo = object : ModernTreasuryPageInfo {
             override val afterCursor: String? = nextAfterCursor

--- a/client/src/main/kotlin/com/classpass/moderntreasury/fake/ModernTreasuryFake.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/fake/ModernTreasuryFake.kt
@@ -97,19 +97,24 @@ open class ModernTreasuryFake :
     override fun getLedgerAccounts(
         ledgerAccountIds: List<LedgerAccountId>,
         balancesAsOfDate: LocalDate?,
-        page: Int,
+        afterCursor: LedgerAccountId?,
         perPage: Int
     ): CompletableFuture<ModernTreasuryPage<LedgerAccount>> = supplyAsync {
         // Create a local copy of ledger account info with computed balance. Does not mutate shared.
         val accounts = ledgerAccountIds.mapNotNull {
             accounts[it]?.copy(balances = getBalances(it, asOfDate = balancesAsOfDate))
         }
+
+        val accountsAfterCursor = accounts.takeLastWhile { afterCursor != it.id }
+
+        val content = accountsAfterCursor.take(perPage)
+        val nextAfterCursor =
+            if (accountsAfterCursor.size <= perPage) null else content.lastOrNull()?.id.toString()
+
         val modernTreasuryPageInfo = object : ModernTreasuryPageInfo {
-            override val page = page
+            override val afterCursor: String? = nextAfterCursor
             override val perPage = perPage
-            override val totalCount = accounts.size
         }
-        val content = accounts.drop((page - 1) * perPage).take(perPage)
         ModernTreasuryPage(modernTreasuryPageInfo, content)
     }
 
@@ -159,7 +164,7 @@ open class ModernTreasuryFake :
         effectiveDate: DateQuery?,
         postedAt: InstantQuery?,
         updatedAt: InstantQuery?,
-        page: Int,
+        afterCursor: LedgerTransactionId?,
         perPage: Int
     ): CompletableFuture<ModernTreasuryPage<LedgerTransaction>> {
         val filteredTransactions = transactions
@@ -175,12 +180,17 @@ open class ModernTreasuryFake :
             }
             .filter { ledgerAccountId == null || it.ledgerEntries.map { entry -> entry.ledgerAccountId }.contains(ledgerAccountId) }
 
+        val transactionsAfterCursor = filteredTransactions.takeLastWhile { afterCursor != it.id }
+
+        val pageContent = transactionsAfterCursor.take(perPage)
+        val nextAfterCursor =
+            if (transactionsAfterCursor.size <= perPage) null else pageContent.lastOrNull()?.id.toString()
+
         val modernTreasuryPageInfo = object : ModernTreasuryPageInfo {
-            override val page = page
+            override val afterCursor: String? = nextAfterCursor
             override val perPage = perPage
-            override val totalCount = filteredTransactions.size
         }
-        val pageContent = filteredTransactions.drop((page - 1) * perPage).take(perPage)
+
         // updatedAt not currently implemented in client
         return completedFuture(ModernTreasuryPage(modernTreasuryPageInfo, pageContent))
     }

--- a/client/src/main/kotlin/com/classpass/moderntreasury/fake/PageInfo.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/fake/PageInfo.kt
@@ -18,7 +18,6 @@ package com.classpass.moderntreasury.fake
 import com.classpass.moderntreasury.model.ModernTreasuryPageInfo
 
 internal data class PageInfo(
-    override val page: Int,
+    override val afterCursor: String?,
     override val perPage: Int,
-    override val totalCount: Int
 ) : ModernTreasuryPageInfo

--- a/client/src/main/kotlin/com/classpass/moderntreasury/model/ModernTreasuryPage.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/model/ModernTreasuryPage.kt
@@ -18,9 +18,8 @@ package com.classpass.moderntreasury.model
 import org.asynchttpclient.Response
 
 // ModernTreasury uses these headers to communicate pagination information on their responses
-internal const val PAGE_HEADER = "x-page"
+internal const val AFTER_CURSOR = "x-after-cursor"
 internal const val PER_PAGE_HEADER = "x-per-page"
-internal const val TOTAL_COUNT_HEADER = "x-total-count"
 
 /**
  * Represents a page of content returned from a paginated "List" endpoint on ModernTreasury.
@@ -34,42 +33,34 @@ data class ModernTreasuryPage<T>(
 ) : ModernTreasuryPageInfo by pageInfo
 
 /**
- * Metadata about a page of content from the ModernTreasury API. includes the current page, number of records per page,
- * and the total number of records.
+ * Metadata about a page of content from the ModernTreasury API.
  */
 interface ModernTreasuryPageInfo {
     /**
-     * The current page
+     * The cursor for the next page
      */
-    val page: Int
+    val afterCursor: String?
 
     /**
      * The number of records on each page
      */
     val perPage: Int
-
-    /**
-     * The total number of records
-     */
-    val totalCount: Int
 }
 
 private data class ModernTreasuryPageInfoImp(
-    override val page: Int,
+    override val afterCursor: String?,
     override val perPage: Int,
-    override val totalCount: Int
 ) : ModernTreasuryPageInfo
 
 /**
  * Extract pagination metadata from a ModernTreasury API response by examining its headers.
  */
 fun Response.extractPageInfo(): ModernTreasuryPageInfo? = this.let { response ->
-    val page = response.getHeader(PAGE_HEADER)?.toInt()
+    val afterCursor = response.getHeader(AFTER_CURSOR)
     val perPage = response.getHeader(PER_PAGE_HEADER)?.toInt()
-    val totalCount = response.getHeader(TOTAL_COUNT_HEADER)?.toInt()
-    return if (page == null || perPage == null || totalCount == null) {
+    return if (perPage == null) {
         null
     } else {
-        ModernTreasuryPageInfoImp(page, perPage, totalCount)
+        ModernTreasuryPageInfoImp(afterCursor?.ifEmpty { null }, perPage)
     }
 }

--- a/client/src/test/kotlin/com/classpass/moderntreasury/client/AsyncModernTreasuryClientTest.kt
+++ b/client/src/test/kotlin/com/classpass/moderntreasury/client/AsyncModernTreasuryClientTest.kt
@@ -119,6 +119,7 @@ class AsyncModernTreasuryClientTest : WireMockClientTest() {
 
     @Test
     fun `test paginated response deserialization`() {
+        val transactionId = UUID.randomUUID().toString()
         stubFor(
             get(anyUrl()).willReturn(
                 ledgerTransactionsListResponse(
@@ -127,16 +128,14 @@ class AsyncModernTreasuryClientTest : WireMockClientTest() {
                     UUID.randomUUID(),
                     UUID.randomUUID()
                 )
-                    .withHeader("x-page", "1")
+                    .withHeader("x-after-cursor", transactionId)
                     .withHeader("x-per-page", "3")
-                    .withHeader("x-total-count", "40")
             )
         )
 
         val result = client.getLedgerTransactions(LedgerId(UUID.randomUUID())).get()
-        assertThat(result.page).isEqualTo(1)
+        assertThat(result.afterCursor).isEqualTo(transactionId)
         assertThat(result.perPage).isEqualTo(3)
-        assertThat(result.totalCount).isEqualTo(40)
         assertThat(result.content).hasSize(3)
         assertThat(result.content[0]).isInstanceOf(LedgerTransaction::class)
     }

--- a/client/src/test/kotlin/com/classpass/moderntreasury/fake/ModernTreasuryFakeTest.kt
+++ b/client/src/test/kotlin/com/classpass/moderntreasury/fake/ModernTreasuryFakeTest.kt
@@ -26,7 +26,6 @@ import com.classpass.moderntreasury.exception.LedgerAccountVersionConflictExcept
 import com.classpass.moderntreasury.exception.ModernTreasuryApiException
 import com.classpass.moderntreasury.model.LedgerAccountId
 import com.classpass.moderntreasury.model.LedgerEntryDirection
-import com.classpass.moderntreasury.model.LedgerTransactionId
 import com.classpass.moderntreasury.model.LedgerTransactionStatus
 import com.classpass.moderntreasury.model.NormalBalanceType
 import com.classpass.moderntreasury.model.request.DateQuery
@@ -312,7 +311,7 @@ class ModernTreasuryFakeTest {
         val result = client.fetchAllPages({ afterCursor, perPage ->
             getLedgerTransactions(
                 ledgerAccountId = usd_cash.id,
-                afterCursor = afterCursor?.let { LedgerTransactionId(it) },
+                afterCursor = afterCursor,
                 perPage = perPage
             )
         }).get()
@@ -336,7 +335,7 @@ class ModernTreasuryFakeTest {
         val result = client.fetchAllPages({ afterCursor, perPage ->
             getLedgerTransactions(
                 ledgerAccountId = usd_cash.id,
-                afterCursor = afterCursor?.let { LedgerTransactionId(it) },
+                afterCursor = afterCursor,
                 perPage = perPage
             )
         }).get()
@@ -348,7 +347,7 @@ class ModernTreasuryFakeTest {
         val result = client.fetchAllPages({ afterCursor, perPage ->
             getLedgerTransactions(
                 ledgerAccountId = usd_cash.id,
-                afterCursor = afterCursor?.let { LedgerTransactionId(it) },
+                afterCursor = afterCursor,
                 perPage = perPage
             )
         }).get()

--- a/live-test/src/test/kotlin/com/classpass/moderntreasury/client/FetchAllPagesLiveTest.kt
+++ b/live-test/src/test/kotlin/com/classpass/moderntreasury/client/FetchAllPagesLiveTest.kt
@@ -21,7 +21,6 @@ import com.classpass.moderntreasury.ModernTreasuryLiveTest
 import com.classpass.moderntreasury.model.Ledger
 import com.classpass.moderntreasury.model.LedgerAccount
 import com.classpass.moderntreasury.model.LedgerEntryDirection
-import com.classpass.moderntreasury.model.LedgerTransactionId
 import com.classpass.moderntreasury.model.LedgerTransactionStatus
 import com.classpass.moderntreasury.model.NormalBalanceType
 import com.classpass.moderntreasury.model.request.RequestLedgerEntry
@@ -74,7 +73,7 @@ class FetchAllPagesLiveTest : ModernTreasuryLiveTest() {
         val actual = client.fetchAllPages({ afterCursor, perPage ->
             getLedgerTransactions(
                 ledgerAccountId = ledgerAccount.id,
-                afterCursor = afterCursor?.let { LedgerTransactionId(it) },
+                afterCursor = afterCursor,
                 perPage = 1
             )
         }).get()

--- a/live-test/src/test/kotlin/com/classpass/moderntreasury/client/FetchAllPagesLiveTest.kt
+++ b/live-test/src/test/kotlin/com/classpass/moderntreasury/client/FetchAllPagesLiveTest.kt
@@ -21,6 +21,7 @@ import com.classpass.moderntreasury.ModernTreasuryLiveTest
 import com.classpass.moderntreasury.model.Ledger
 import com.classpass.moderntreasury.model.LedgerAccount
 import com.classpass.moderntreasury.model.LedgerEntryDirection
+import com.classpass.moderntreasury.model.LedgerTransactionId
 import com.classpass.moderntreasury.model.LedgerTransactionStatus
 import com.classpass.moderntreasury.model.NormalBalanceType
 import com.classpass.moderntreasury.model.request.RequestLedgerEntry
@@ -55,7 +56,7 @@ class FetchAllPagesLiveTest : ModernTreasuryLiveTest() {
     }
 
     @Test
-    fun `fetchAllPages fetches all pages`() {
+    fun `live fetchAllPages fetches all pages`() {
         val transactions = List(5) { idx ->
             client.createLedgerTransaction(
                 LocalDate.now(),
@@ -70,10 +71,10 @@ class FetchAllPagesLiveTest : ModernTreasuryLiveTest() {
             )
         }.map { it.get() }
 
-        val actual = client.fetchAllPages({ page, perPage ->
+        val actual = client.fetchAllPages({ afterCursor, perPage ->
             getLedgerTransactions(
                 ledgerAccountId = ledgerAccount.id,
-                page = page,
+                afterCursor = afterCursor?.let { LedgerTransactionId(it) },
                 perPage = 1
             )
         }).get()


### PR DESCRIPTION
Modern Treasury are changing their API to use Cursor based pagination https://docs.moderntreasury.com/reference/cursor-pagination. This PR updates the get accounts and get transactions functions accordingly. 