### PR TITLE
Use kotlinModule helper instead of KotlinModule constructor

### DIFF
--- a/client/src/main/kotlin/com/classpass/moderntreasury/SandboxTest.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/SandboxTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/main/kotlin/com/classpass/moderntreasury/client/AsyncModernTreasuryClient.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/client/AsyncModernTreasuryClient.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/main/kotlin/com/classpass/moderntreasury/client/AsyncModernTreasuryClient.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/client/AsyncModernTreasuryClient.kt
@@ -42,8 +42,8 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
+import com.fasterxml.jackson.module.kotlin.kotlinModule
 import com.google.common.util.concurrent.RateLimiter
 import org.asynchttpclient.AsyncHttpClient
 import org.asynchttpclient.BoundRequestBuilder
@@ -92,7 +92,7 @@ internal class AsyncModernTreasuryClient(
     }
 
     private val objectMapper: ObjectMapper = JsonMapper.builder()
-        .addModules(KotlinModule(), JavaTimeModule())
+        .addModules(kotlinModule(), JavaTimeModule())
         .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
         .configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, true)
         .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)

--- a/client/src/main/kotlin/com/classpass/moderntreasury/client/FetchAllPages.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/client/FetchAllPages.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/main/kotlin/com/classpass/moderntreasury/client/ModernTreasuryClient.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/client/ModernTreasuryClient.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/main/kotlin/com/classpass/moderntreasury/client/ResponseCallback.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/client/ResponseCallback.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/main/kotlin/com/classpass/moderntreasury/config/ModernTreasuryConfig.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/config/ModernTreasuryConfig.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/main/kotlin/com/classpass/moderntreasury/exception/DuplicateExternalIdException.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/exception/DuplicateExternalIdException.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/main/kotlin/com/classpass/moderntreasury/exception/LedgerAccountVersionConflictException.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/exception/LedgerAccountVersionConflictException.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/main/kotlin/com/classpass/moderntreasury/exception/MissingPaginationHeadersException.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/exception/MissingPaginationHeadersException.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/main/kotlin/com/classpass/moderntreasury/exception/ModernTreasuryApiException.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/exception/ModernTreasuryApiException.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/main/kotlin/com/classpass/moderntreasury/exception/ModernTreasuryClientException.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/exception/ModernTreasuryClientException.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/main/kotlin/com/classpass/moderntreasury/exception/RateLimitTimeoutException.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/exception/RateLimitTimeoutException.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/main/kotlin/com/classpass/moderntreasury/exception/TransactionAlreadyPostedException.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/exception/TransactionAlreadyPostedException.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/main/kotlin/com/classpass/moderntreasury/fake/Accumulator.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/fake/Accumulator.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/main/kotlin/com/classpass/moderntreasury/fake/Exceptions.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/fake/Exceptions.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/main/kotlin/com/classpass/moderntreasury/fake/ModernTreasuryFake.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/fake/ModernTreasuryFake.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/main/kotlin/com/classpass/moderntreasury/fake/PageInfo.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/fake/PageInfo.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/main/kotlin/com/classpass/moderntreasury/fake/Utilities.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/fake/Utilities.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/main/kotlin/com/classpass/moderntreasury/model/Ledger.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/model/Ledger.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/main/kotlin/com/classpass/moderntreasury/model/LedgerAccount.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/model/LedgerAccount.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/main/kotlin/com/classpass/moderntreasury/model/LedgerAccountBalances.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/model/LedgerAccountBalances.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/main/kotlin/com/classpass/moderntreasury/model/LedgerEntry.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/model/LedgerEntry.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/main/kotlin/com/classpass/moderntreasury/model/LedgerTransaction.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/model/LedgerTransaction.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/main/kotlin/com/classpass/moderntreasury/model/ModernTreasuryPage.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/model/ModernTreasuryPage.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/main/kotlin/com/classpass/moderntreasury/model/request/CreateLedgerAccountRequest.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/model/request/CreateLedgerAccountRequest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/main/kotlin/com/classpass/moderntreasury/model/request/CreateLedgerRequest.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/model/request/CreateLedgerRequest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/main/kotlin/com/classpass/moderntreasury/model/request/CreateLedgerTransactionRequest.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/model/request/CreateLedgerTransactionRequest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/main/kotlin/com/classpass/moderntreasury/model/request/IdempotentRequest.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/model/request/IdempotentRequest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/main/kotlin/com/classpass/moderntreasury/model/request/ModernTreasuryTemporalQuery.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/model/request/ModernTreasuryTemporalQuery.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/main/kotlin/com/classpass/moderntreasury/model/request/RequestLedgerEntry.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/model/request/RequestLedgerEntry.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/main/kotlin/com/classpass/moderntreasury/model/request/RequestMetadata.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/model/request/RequestMetadata.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/main/kotlin/com/classpass/moderntreasury/model/request/UpdateLedgerTransactionRequest.kt
+++ b/client/src/main/kotlin/com/classpass/moderntreasury/model/request/UpdateLedgerTransactionRequest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/test/kotlin/com/classpass/moderntreasury/client/AsyncModernTreasuryClientTest.kt
+++ b/client/src/test/kotlin/com/classpass/moderntreasury/client/AsyncModernTreasuryClientTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/test/kotlin/com/classpass/moderntreasury/client/LedgerAccountTests.kt
+++ b/client/src/test/kotlin/com/classpass/moderntreasury/client/LedgerAccountTests.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/test/kotlin/com/classpass/moderntreasury/client/LedgerTests.kt
+++ b/client/src/test/kotlin/com/classpass/moderntreasury/client/LedgerTests.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/test/kotlin/com/classpass/moderntreasury/client/LedgerTransactionTests.kt
+++ b/client/src/test/kotlin/com/classpass/moderntreasury/client/LedgerTransactionTests.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/test/kotlin/com/classpass/moderntreasury/client/RateLimitingTest.kt
+++ b/client/src/test/kotlin/com/classpass/moderntreasury/client/RateLimitingTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/test/kotlin/com/classpass/moderntreasury/client/WireMockClientTest.kt
+++ b/client/src/test/kotlin/com/classpass/moderntreasury/client/WireMockClientTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/test/kotlin/com/classpass/moderntreasury/exception/LedgerAccountVersionConflictExceptionTest.kt
+++ b/client/src/test/kotlin/com/classpass/moderntreasury/exception/LedgerAccountVersionConflictExceptionTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/test/kotlin/com/classpass/moderntreasury/exception/TransactionAlreadyPostedExceptionTest.kt
+++ b/client/src/test/kotlin/com/classpass/moderntreasury/exception/TransactionAlreadyPostedExceptionTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/test/kotlin/com/classpass/moderntreasury/fake/ModernTreasuryFakeTest.kt
+++ b/client/src/test/kotlin/com/classpass/moderntreasury/fake/ModernTreasuryFakeTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/test/kotlin/com/classpass/moderntreasury/model/request/ModernTreasuryTemporalQueryTest.kt
+++ b/client/src/test/kotlin/com/classpass/moderntreasury/model/request/ModernTreasuryTemporalQueryTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/client/src/test/resources/logback-test.xml
+++ b/client/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2024 ClassPass
+    Copyright 2025 ClassPass
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.

--- a/live-test/src/test/kotlin/com/classpass/moderntreasury/ModernTreasuryLiveTest.kt
+++ b/live-test/src/test/kotlin/com/classpass/moderntreasury/ModernTreasuryLiveTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/live-test/src/test/kotlin/com/classpass/moderntreasury/client/FetchAllPagesLiveTest.kt
+++ b/live-test/src/test/kotlin/com/classpass/moderntreasury/client/FetchAllPagesLiveTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/live-test/src/test/kotlin/com/classpass/moderntreasury/client/LedgerAccountLiveTest.kt
+++ b/live-test/src/test/kotlin/com/classpass/moderntreasury/client/LedgerAccountLiveTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/live-test/src/test/kotlin/com/classpass/moderntreasury/client/LedgerCrudTest.kt
+++ b/live-test/src/test/kotlin/com/classpass/moderntreasury/client/LedgerCrudTest.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 ClassPass
+ * Copyright 2025 ClassPass
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.


### PR DESCRIPTION
`KotlinModule()` is prone to ABI compatibility issues; `kotlinModule()` is preferred.